### PR TITLE
[fix] Use min-width instead of width

### DIFF
--- a/assets/scss/skills.scss
+++ b/assets/scss/skills.scss
@@ -11,7 +11,7 @@
 
     .article {
       break-inside: avoid-column;
-      width: $skills-column-width;
+      min-width: $skills-column-width;
       padding-top: $space-2;
 
       span {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -254,7 +254,7 @@ li {
   column-gap: 10px; }
   .skills .container .article {
     break-inside: avoid-column;
-    width: 120px;
+    min-width: 120px;
     padding-top: 20px; }
     .skills .container .article span {
       display: block;


### PR DESCRIPTION
When following section contents (e.g. education or certificates) is wider than two times the width of the skill container the skill container will get too much whitespace on the right. Using a min-width will fix the issue.

## Before

![Screenshot 2022-05-03 at 13 30 47](https://user-images.githubusercontent.com/4550875/166446295-3a55e2e3-93f3-4ae9-bb7e-110d78cc3fcc.png)

## After

![image](https://user-images.githubusercontent.com/4550875/166446490-a9a37505-d993-48c6-88a9-66dd19d0ac80.png)

