### PR TITLE
[fix] Display work duration on one line only

### DIFF
--- a/assets/scss/work.scss
+++ b/assets/scss/work.scss
@@ -31,6 +31,7 @@
         .dates {
           font-size: $work-dates-font-size;
           font-weight: lighter;
+          white-space: nowrap;
         }
       }
     }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -217,7 +217,8 @@ li {
     display: table-cell; }
     .work .header .table .right .dates {
       font-size: 15px;
-      font-weight: lighter; }
+      font-weight: lighter;
+      white-space: nowrap; }
 
 .work .summary {
   font-size: 16px;


### PR DESCRIPTION
I noticed when a work location address was too long the work duration will use multiple lines. Using `white-space: nowrap;` will make sure the work duration will be displayed on one line only.

## Before

![Screenshot 2022-05-06 at 14 49 10](https://user-images.githubusercontent.com/4550875/167135521-04f5da84-e020-4252-b917-30a101d8afbe.png)

## After

![Screenshot 2022-05-06 at 14 49 28](https://user-images.githubusercontent.com/4550875/167135551-9dc3a719-c4c0-4b80-802a-11f12314f12c.png)